### PR TITLE
Deduplicate imports and constants

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -7,9 +7,6 @@ import math
 import json
 import time
 import yaml
-from pathlib import Path
-from datetime import datetime
-CFG_PATH = "config.yaml"
 import asyncio
 import subprocess
 from datetime import datetime, timedelta

--- a/db.py
+++ b/db.py
@@ -18,9 +18,7 @@ DB_NAME = os.getenv("DB_NAME", "tg_analyzer")
 
 DATABASE_URL = f"postgresql+psycopg2://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 engine = create_engine(DATABASE_URL, echo=False, pool_pre_ping=True)
-
-from sqlmodel import SQLModel
-SQLModel.metadata.clear() 
+SQLModel.metadata.clear()
 
 # --- Models ---
 

--- a/utils.py
+++ b/utils.py
@@ -12,15 +12,6 @@ def setup_logger(log_path: str):
                 return dt.strftime(datefmt)
             return dt.isoformat()
 
-    import logging, pytz
-    from datetime import datetime
-    class TZFormatter(logging.Formatter):
-        def formatTime(self, record, datefmt=None):
-            dt = datetime.fromtimestamp(record.created, tz=ZoneInfo("Europe/Bucharest"))
-            if datefmt:
-                return dt.strftime(datefmt)
-            return dt.isoformat()
-    
     pathlib.Path(log_path).parent.mkdir(parents=True, exist_ok=True)
     logger.remove()
     logger.add(log_path, rotation="20 MB", retention="15 days", enqueue=True)

--- a/worker.py
+++ b/worker.py
@@ -29,7 +29,6 @@ from db import (
     AccountChat, ChatBot, DirectPeer
 )
 from utils import setup_logger, sleep_range, jitter_ms
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 # --- Константы/пути ---
 BUCHAREST_TZ = ZoneInfo("Europe/Bucharest")
@@ -147,7 +146,7 @@ async def ensure_chat_record(sess, entity, account_id: int):
     sess.commit()
 
 def insert_message_no_conflict(sess, **vals):
-    stmt = pg_insert(Message.__table__).values(**vals).on_conflict_do_nothing(index_elements=[\x27chat_id\x27, \x27message_id\x27])
+    stmt = pg_insert(Message.__table__).values(**vals).on_conflict_do_nothing(index_elements=['chat_id', 'message_id'])
     sess.exec(stmt)
 
 async def save_messages(sess, entity, msgs, account_id: int):


### PR DESCRIPTION
## Summary
- ensure `dashboard_app.py` has single `CFG_PATH`, `datetime` and `Path` imports
- remove redundant SQLModel import in `db.py`
- clean up logger utilities and duplicated imports in `utils.py`
- drop duplicate `pg_insert` import and correct insert helper in `worker.py`

## Testing
- `python -m py_compile dashboard_app.py db.py utils.py worker.py dashboard_plus.py migrate.py migrate_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_68a991771d64832bab58ae1b403dff31