### PR TITLE
Add worker PID file cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ uvloop==0.19.0; platform_system != "Windows"
 pandas==2.2.2
 pyarrow==16.1.0
 psycopg2-binary==2.9.9
+psutil==6.0.0


### PR DESCRIPTION
## Summary
- manage worker instance with PID file instead of lock
- clean up PID and heartbeat on exit
- depend on psutil for PID checks

## Testing
- ⚠️ `pip install psutil==6.0.0` (403 error)
- ✅ `python -m py_compile worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9cbe1882c832bbf762ea5d09e1a6e