### PR TITLE
Remove worker service from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,3 @@ services:
       - ./:/app
     restart: unless-stopped
 
-  worker:
-    build: .
-    container_name: tg-worker
-    env_file:
-      - .env
-    command: ["python", "worker.py"]
-    volumes:
-      - ./:/app
-    restart: unless-stopped


### PR DESCRIPTION
## Summary
- remove worker service from docker-compose, leaving only dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9cbe2e594832baf58454432e7a7e6