### PR TITLE
Handle chat processing errors without stopping worker

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -396,11 +396,17 @@ async def main():
         if USE_TAKEOUT:
             async with client_ctx.takeout() as client:
                 for c in chats:
-                    await process_chat(client, c, acc_id)
+                    try:
+                        await process_chat(client, c, acc_id)
+                    except Exception:
+                        logger.exception(f"failed to process {c}")
                     sleep_range(*PCHAT)
         else:
             for c in chats:
-                await process_chat(client_ctx, c, acc_id)
+                try:
+                    await process_chat(client_ctx, c, acc_id)
+                except Exception:
+                    logger.exception(f"failed to process {c}")
                 sleep_range(*PCHAT)
 
     write_heartbeat(last_action="finish", mode="done")


### PR DESCRIPTION
## Summary
- continue processing chats even if a single chat fails
- log exceptions during chat processing so the worker can move on

## Testing
- `python -m py_compile worker.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9d5b00990832ba2deaa7155364825