### PR TITLE
fix: add PyYAML dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pandas==2.2.2
 pyarrow==16.1.0
 psycopg2-binary==2.9.9
 psutil==6.0.0
+PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- include PyYAML in Python requirements so worker can load YAML config

## Testing
- `pip install PyYAML==6.0.1` *(fails: Could not connect to proxy, 403 Forbidden)*
- `python -m py_compile worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9e2762ccc832b89239badec6a6177