### PR TITLE
Fix chat textarea reload with dynamic session key

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -312,7 +312,12 @@ with tabs[2]:
     # === Перезагрузка формы из config.yaml ===
     def _cfg_to_state():
         cfg = load_cfg()
-        st.session_state["cfg_chats"] = "\n".join(map(str, cfg.get("chats", [])))
+        try:
+            cfg_mtime = Path(CFG_PATH).stat().st_mtime
+        except Exception:
+            cfg_mtime = 0
+        nonce = str(int(cfg_mtime))
+        st.session_state[f"chats_text_{nonce}"] = "\n".join(map(str, cfg.get("chats", [])))
         st.session_state["cfg_batch_lo"] = int(cfg["limits"]["batch_size_range"][0])
         st.session_state["cfg_batch_hi"] = int(cfg["limits"]["batch_size_range"][1])
         st.session_state["cfg_pbb_lo"] = float(cfg["limits"]["pause_between_batches_sec"][0])


### PR DESCRIPTION
## Summary
- Align `_cfg_to_state` with textarea by computing config nonce and setting `chats_text_{nonce}` session state
- Ensure reload button repopulates "chats" field from `config.yaml`

## Testing
- `python -m py_compile dashboard_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9d5adc24c832b9b0799a95a50a9bb