### PR TITLE
Configure dashboard service with database and persistent storage

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 API_ID=15818412
 API_HASH=ee2f43902dbe55a0bbe42d3a6dc10434
 SESSION_NAME=research_account
-DB_HOST=127.0.0.1
+DB_HOST=db
 DB_PORT=5432
 DB_NAME=tg_analyzer
 DB_USER=tgadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,34 @@
 version: "3.9"
+
 services:
   dashboard:
     build: .
     container_name: tg-dashboard
+    init: true
     env_file:
       - .env
+    depends_on:
+      - db
     ports:
       - "8501:8501"
     volumes:
-      - ./:/app
+      - ./research_account.session:/app/research_account.session
+      - ./config.yaml:/app/config.yaml
+      - ./runtime:/app/runtime
+      - ./logs:/app/logs
     restart: unless-stopped
+
+  db:
+    image: postgres:15-alpine
+    container_name: tg-db
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+volumes:
+  db_data:
 


### PR DESCRIPTION
## Summary
- add `init: true` and persistent volumes for session, config, runtime and logs
- include PostgreSQL service and update `DB_HOST` to use service name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a726500832b9b098ff32adca146