### PR TITLE
Handle database connection failures gracefully

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -277,7 +277,7 @@ with tabs[0]:
         if last_dt:
             st.caption(f"Последнее сообщение в базе: {last_dt}")
     except Exception as e:
-        st.warning(f"Не удалось получить метрики БД: {e}")
+        st.warning(f"Нет подключения к БД: {e}")
 
     # Хвост лога воркера
     st.divider()

--- a/worker.py
+++ b/worker.py
@@ -25,10 +25,6 @@ from telethon.tl.types import User as TLUser, Channel, Chat as TLChat
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 
-from db import (
-    get_session, Account, User, Chat, Message, Cursor, Window,
-    AccountChat, ChatBot, DirectPeer
-)
 from utils import setup_logger, sleep_range, jitter_ms
 
 # --- Константы/пути ---
@@ -80,6 +76,15 @@ with open("config.yaml", "r", encoding="utf-8") as f:
 
 LOG_PATH = CFG["storage"]["log_path"]
 logger = setup_logger(LOG_PATH)
+
+try:
+    from db import (
+        get_session, Account, User, Chat, Message, Cursor, Window,
+        AccountChat, ChatBot, DirectPeer, engine
+    )
+except Exception as e:
+    logger.error(f"Не удалось создать engine: {e}")
+    sys.exit(1)
 
 BATCH_MIN, BATCH_MAX = CFG["limits"]["batch_size_range"]
 PBATCH = CFG["limits"]["pause_between_batches_sec"]


### PR DESCRIPTION
## Summary
- warn in metrics block when database connection is missing
- exit worker if database engine cannot be created

## Testing
- `python -m py_compile dashboard_app.py worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa2a7a138c832bb6aa7a8ea214a543