### PR TITLE
Add Docker ignore and refine build layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Ignore version control files
+.git
+.gitignore
+.github
+
+# Development environments
+.devcontainer/
+.venv/
+.env
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+
+# Logs and runtime files
+*.log
+*.session
+logs/
+runtime/
+idle/
+data/
+exports/
+streamlit.log
+worker.log
+
+# Backup files
+*.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.11-slim
+
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
-COPY requirements.txt .
+
+COPY requirements.txt /app/
 RUN pip install -r requirements.txt
-COPY . .
+
+COPY . /app
 CMD ["streamlit", "run", "dashboard_app.py", "--server.address", "0.0.0.0", "--server.port", "8501"]


### PR DESCRIPTION
## Summary
- Exclude development artifacts and runtime data from images via `.dockerignore`
- Copy `requirements.txt` before source code in `Dockerfile` to leverage Docker layer caching

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `apt-get update` *(fails: 403  Forbidden)*
- `apt-get install -y docker.io` *(fails: Unable to locate package)*
- `docker build -t tg_analyzer_test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a72fe7c832b93df4d3303ab3c04